### PR TITLE
[Fix] when home focusnodes index exceeds the maximum value, keyboard d…

### DIFF
--- a/tig/lib/presentation/screens/home/home_screen.dart
+++ b/tig/lib/presentation/screens/home/home_screen.dart
@@ -77,7 +77,11 @@ class _HomeScreen extends ConsumerState<HomeScreen>
   }
 
   void _moveToNextTextField() {
-    if (_focusedNodeIndex! > _dailyPriorityControllers.length - 1) return;
+    if (_focusedNodeIndex! >= _dailyPriorityControllers.length - 1) {
+      FocusManager.instance.primaryFocus?.unfocus();
+      return;
+    }
+
     _focusedNodeIndex = _focusedNodeIndex! + 1;
     FocusScope.of(context)
         .requestFocus(_activityFocusNodes[_focusedNodeIndex!]);


### PR DESCRIPTION
## 간단설명
- 최대 인덱스를 초과하지 못하도록 조건문을 수정하고, 넘어가게 되면 키보드를 사라지게 하기