### PR TITLE
[Hotfix] resolve text overflows in descriptions of time system

### DIFF
--- a/tig/lib/generated/intl/messages_de.dart
+++ b/tig/lib/generated/intl/messages_de.dart
@@ -145,10 +145,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "next": MessageLookupByLibrary.simpleMessage("Weiter"),
     "ok": MessageLookupByLibrary.simpleMessage("OK"),
     "option_explain_twelve": MessageLookupByLibrary.simpleMessage(
-      "Im 12-Stunden-Format anzeigen. (1:00 PM ... 12:00 PM)",
+      "Im 12-Stunden-Format anzeigen.\n(1:00 PM ... 12:00 PM)",
     ),
     "option_explain_twentyFour": MessageLookupByLibrary.simpleMessage(
-      "Im 24-Stunden-Format anzeigen. (13:00 ... 24:00)",
+      "Im 24-Stunden-Format anzeigen.\n(13:00 ... 24:00)",
     ),
     "setting": MessageLookupByLibrary.simpleMessage("Einstellungen"),
     "success": MessageLookupByLibrary.simpleMessage("Erfolg"),

--- a/tig/lib/generated/intl/messages_en.dart
+++ b/tig/lib/generated/intl/messages_en.dart
@@ -134,10 +134,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "next": MessageLookupByLibrary.simpleMessage("Next"),
     "ok": MessageLookupByLibrary.simpleMessage("OK"),
     "option_explain_twelve": MessageLookupByLibrary.simpleMessage(
-      "Displayed in 12-hour format. (1:00 PM ... 12:00 PM)",
+      "Displayed in 12-hour format.\n(1:00 PM ... 12:00 PM)",
     ),
     "option_explain_twentyFour": MessageLookupByLibrary.simpleMessage(
-      "Displayed in 24-hour format. (13:00 ... 24:00)",
+      "Displayed in 24-hour format.\n(13:00 ... 24:00)",
     ),
     "setting": MessageLookupByLibrary.simpleMessage("Settings"),
     "success": MessageLookupByLibrary.simpleMessage("Success"),

--- a/tig/lib/generated/intl/messages_es.dart
+++ b/tig/lib/generated/intl/messages_es.dart
@@ -144,10 +144,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "next": MessageLookupByLibrary.simpleMessage("Siguiente"),
     "ok": MessageLookupByLibrary.simpleMessage("Aceptar"),
     "option_explain_twelve": MessageLookupByLibrary.simpleMessage(
-      "Se muestra en formato de 12 horas. (1:00 PM ... 12:00 PM)",
+      "Se muestra en formato de 12 horas.\n(1:00 PM ... 12:00 PM)",
     ),
     "option_explain_twentyFour": MessageLookupByLibrary.simpleMessage(
-      "Se muestra en formato de 24 horas. (13:00 ... 24:00)",
+      "Se muestra en formato de 24 horas.\n(13:00 ... 24:00)",
     ),
     "setting": MessageLookupByLibrary.simpleMessage("Configuración"),
     "success": MessageLookupByLibrary.simpleMessage("Éxito"),

--- a/tig/lib/generated/intl/messages_pt.dart
+++ b/tig/lib/generated/intl/messages_pt.dart
@@ -140,10 +140,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "next": MessageLookupByLibrary.simpleMessage("próximo"),
     "ok": MessageLookupByLibrary.simpleMessage("verificar"),
     "option_explain_twelve": MessageLookupByLibrary.simpleMessage(
-      "Exibido no formato de 12 horas. (1:00 PM ... 12:00 PM)",
+      "Exibido no formato de 12 horas.\n(1:00 PM ... 12:00 PM)",
     ),
     "option_explain_twentyFour": MessageLookupByLibrary.simpleMessage(
-      "Exibido no formato de 24 horas. (13:00 ... 24:00)",
+      "Exibido no formato de 24 horas.\n(13:00 ... 24:00)",
     ),
     "setting": MessageLookupByLibrary.simpleMessage("contexto"),
     "success": MessageLookupByLibrary.simpleMessage("sucesso"),

--- a/tig/lib/generated/l10n.dart
+++ b/tig/lib/generated/l10n.dart
@@ -620,20 +620,20 @@ class S {
     );
   }
 
-  /// `Displayed in 12-hour format. (1:00 PM ... 12:00 PM)`
+  /// `Displayed in 12-hour format.\n(1:00 PM ... 12:00 PM)`
   String get option_explain_twelve {
     return Intl.message(
-      'Displayed in 12-hour format. (1:00 PM ... 12:00 PM)',
+      'Displayed in 12-hour format.\n(1:00 PM ... 12:00 PM)',
       name: 'option_explain_twelve',
       desc: '',
       args: [],
     );
   }
 
-  /// `Displayed in 24-hour format. (13:00 ... 24:00)`
+  /// `Displayed in 24-hour format.\n(13:00 ... 24:00)`
   String get option_explain_twentyFour {
     return Intl.message(
-      'Displayed in 24-hour format. (13:00 ... 24:00)',
+      'Displayed in 24-hour format.\n(13:00 ... 24:00)',
       name: 'option_explain_twentyFour',
       desc: '',
       args: [],

--- a/tig/lib/l10n/intl_de.arb
+++ b/tig/lib/l10n/intl_de.arb
@@ -64,6 +64,6 @@
   "tig_mode_waiting": "Warten",
   "tig_mode_remain_time": "Verbleibende Zeit",
   "tig_mode_count_down": "{minute} : {second}",
-  "option_explain_twelve": "Im 12-Stunden-Format anzeigen. (1:00 PM ... 12:00 PM)",
-  "option_explain_twentyFour": "Im 24-Stunden-Format anzeigen. (13:00 ... 24:00)"
+  "option_explain_twelve": "Im 12-Stunden-Format anzeigen.\n(1:00 PM ... 12:00 PM)",
+  "option_explain_twentyFour": "Im 24-Stunden-Format anzeigen.\n(13:00 ... 24:00)"
 }

--- a/tig/lib/l10n/intl_en.arb
+++ b/tig/lib/l10n/intl_en.arb
@@ -64,6 +64,6 @@
   "tig_mode_waiting": "Waiting",
   "tig_mode_remain_time": "Remaining time",
   "tig_mode_count_down": "{minute} : {second}",
-  "option_explain_twelve": "Displayed in 12-hour format. (1:00 PM ... 12:00 PM)",
-  "option_explain_twentyFour": "Displayed in 24-hour format. (13:00 ... 24:00)"
+  "option_explain_twelve": "Displayed in 12-hour format.\n(1:00 PM ... 12:00 PM)",
+  "option_explain_twentyFour": "Displayed in 24-hour format.\n(13:00 ... 24:00)"
 }

--- a/tig/lib/l10n/intl_es.arb
+++ b/tig/lib/l10n/intl_es.arb
@@ -64,6 +64,6 @@
   "tig_mode_waiting": "Esperando",
   "tig_mode_remain_time": "Tiempo restante",
   "tig_mode_count_down": "{minute} : {second}",
-  "option_explain_twelve": "Se muestra en formato de 12 horas. (1:00 PM ... 12:00 PM)",
-  "option_explain_twentyFour": "Se muestra en formato de 24 horas. (13:00 ... 24:00)"
+  "option_explain_twelve": "Se muestra en formato de 12 horas.\n(1:00 PM ... 12:00 PM)",
+  "option_explain_twentyFour": "Se muestra en formato de 24 horas.\n(13:00 ... 24:00)"
 }

--- a/tig/lib/l10n/intl_pt.arb
+++ b/tig/lib/l10n/intl_pt.arb
@@ -64,6 +64,6 @@
   "tig_mode_waiting": "esperando",
   "tig_mode_remain_time": "tempo restante",
   "tig_mode_count_down": "{minute}: {second}",
-  "option_explain_twelve": "Exibido no formato de 12 horas. (1:00 PM ... 12:00 PM)",
-  "option_explain_twentyFour": "Exibido no formato de 24 horas. (13:00 ... 24:00)"
+  "option_explain_twelve": "Exibido no formato de 12 horas.\n(1:00 PM ... 12:00 PM)",
+  "option_explain_twentyFour": "Exibido no formato de 24 horas.\n(13:00 ... 24:00)"
 }

--- a/tig/lib/presentation/screens/home/provider/state/home_state.dart
+++ b/tig/lib/presentation/screens/home/provider/state/home_state.dart
@@ -23,7 +23,7 @@ class HomeState extends Equatable {
     this.tags = const [],
     this.tig,
   });
-
+  
   HomeState copyWith({
     bool? isDayExpanded,
     bool? isAtBottom,

--- a/tig/lib/presentation/screens/option/option_screen.dart
+++ b/tig/lib/presentation/screens/option/option_screen.dart
@@ -115,28 +115,30 @@ class _OptionScreen extends ConsumerState<OptionScreen> {
               ],
             ),
             Row(
-              mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                Expanded(
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      optionState.timeSystem == TimeSystem.twentyFour
-                          ? Text(
-                              Intl.message("option_explain_twentyFour"),
-                              style: const TextStyle(
-                                  fontSize: 11,
-                                  color: Color.fromARGB(255, 118, 118, 118)),
-                            )
-                          : Text(
-                              Intl.message("option_explain_twelve"),
-                              style: const TextStyle(
-                                  fontSize: 11,
-                                  color: Color.fromARGB(255, 118, 118, 118)),
-                            ),
-                    ],
-                  ),
-                ),
+                optionState.timeSystem == TimeSystem.twentyFour
+                    ? Expanded(
+                        child: Text(
+                          textAlign: TextAlign.end,
+                          Intl.message("option_explain_twentyFour"),
+                          maxLines: 3,
+                          overflow: TextOverflow.visible,
+                          style: const TextStyle(
+                              fontSize: 11,
+                              color: Color.fromARGB(255, 118, 118, 118)),
+                        ),
+                      )
+                    : Expanded(
+                        child: Text(
+                          textAlign: TextAlign.end,
+                          Intl.message("option_explain_twelve"),
+                          maxLines: 3,
+                          overflow: TextOverflow.visible,
+                          style: const TextStyle(
+                              fontSize: 11,
+                              color: Color.fromARGB(255, 118, 118, 118)),
+                        ),
+                      ),
               ],
             ),
           ],


### PR DESCRIPTION
## 간단설명
- 시간 표기 시스템 설명 문구의 오버플로우 발생시 화면에 보이지 않는 이슈 수정